### PR TITLE
Fixed zip file detection for cases where the mod is named ".zip", but not ".jar.zip".

### DIFF
--- a/Base/DragonAPIMod.java
+++ b/Base/DragonAPIMod.java
@@ -104,7 +104,7 @@ public abstract class DragonAPIMod {
 
 	protected final void verifyInstallation() {
 		this.verifyVersions();
-		if (this.getModFile().getName().endsWith(".jar.zip"))
+		if (this.getModFile().getName().endsWith(".zip"))
 			throw new JarZipException(this);
 		this.verifyHash();
 	}


### PR DESCRIPTION
Changed the detection to crash when zip files are detected regardless of whether it's called ".jar.zip".