### PR TITLE
Fix HungerOverhaul config class name

### DIFF
--- a/ModInteract/ItemHandlers/HungerOverhaulHandler.java
+++ b/ModInteract/ItemHandlers/HungerOverhaulHandler.java
@@ -26,7 +26,7 @@ public class HungerOverhaulHandler extends ModHandlerBase {
 		int regenFood = -1;
 		if (this.hasMod()) {
 			try {
-				Class c = Class.forName("iguanaman.hungeroverhaul.IguanaConfig");
+				Class c = Class.forName("iguanaman.hungeroverhaul.config.IguanaConfig");
 
 				Field f = c.getField("minHungerToHeal");
 				regenFood = f.getInt(null);


### PR DESCRIPTION
Was moved to `iguanaman.hungeroverhaul.config.IguanaConfig` in the 1.7.10 version of HO

See: http://www.minecraftforum.net/forums/mapping-and-modding/minecraft-mods/2222904-1-7-10-hunger-overhaul?comment=280

> [Client thread/ERROR] [FML]: DRAGONAPI 
ERROR: 1 failure for Hungeroverhaul ('HungerOverhaul'):

> [Client thread/ERROR] [FML]: DRAGONAPI ERROR: 
ClassNotFoundException "iguanaman.hungeroverhaul.IguanaConfig" thrown from Reika.DragonAPI.Base.ModHandlerBase

Relevant HO commit: https://github.com/progwml6/HungerOverhaul/commit/ec3fcadeb5a587d83aeb7757dafcb8974168ffd6