### PR TITLE
Update ReikaJVMParser.java

### DIFF
--- a/Libraries/Java/ReikaJVMParser.java
+++ b/Libraries/Java/ReikaJVMParser.java
@@ -84,7 +84,7 @@ public class ReikaJVMParser {
 
 	private static int[] getJavaVersion() {
 		String v = System.getProperty("java.version");
-		String[] parts = v.replaceAll("_", ".").split("\\.");
+		String[] parts = v.replaceAll("[^0-9\\._]","").replaceAll("_", ".").split("\\.");
 		int[] ret = new int[parts.length-1]; //ignore the "1."
 		for (int i = 0; i < ret.length; i++) {
 			ret[i] = Integer.parseInt(parts[i+1]);


### PR DESCRIPTION
Line 87: strip everything but the version number first. should alleviate problems from rogue alphabetics.
ref:  http://www.minecraftforum.net/forums/mapping-and-modding/minecraft-mods/1291655-reikas-mods-tech-worldgen-civilization-and-more?page=1255#c25426