### PR TITLE
Move debug overlays and popups to front

### DIFF
--- a/Auxiliary/DebugOverlay.java
+++ b/Auxiliary/DebugOverlay.java
@@ -30,6 +30,7 @@ import Reika.DragonAPI.DragonOptions;
 import Reika.DragonAPI.Libraries.ReikaNBTHelper;
 import Reika.DragonAPI.Libraries.ReikaPlayerAPI;
 import Reika.DragonAPI.Libraries.IO.ReikaTextureHelper;
+import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 
 public class DebugOverlay {
@@ -40,8 +41,8 @@ public class DebugOverlay {
 
 	}
 
-	@SubscribeEvent
-	public void eventHandler(RenderGameOverlayEvent event) {
+	@SubscribeEvent(priority = EventPriority.HIGHEST)
+	public void eventHandler(RenderGameOverlayEvent.Post event) {
 		if (event.type == ElementType.HELMET) {
 			if (DragonAPICore.debugtest) {
 				Minecraft mc = Minecraft.getMinecraft();

--- a/Auxiliary/PopupWriter.java
+++ b/Auxiliary/PopupWriter.java
@@ -27,6 +27,7 @@ import Reika.DragonAPI.DragonAPICore;
 import Reika.DragonAPI.Libraries.IO.ReikaGuiAPI;
 import Reika.DragonAPI.Libraries.IO.ReikaTextureHelper;
 import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.eventhandler.EventPriority;
 import cpw.mods.fml.common.eventhandler.SubscribeEvent;
 import cpw.mods.fml.common.gameevent.InputEvent.KeyInputEvent;
 import cpw.mods.fml.relauncher.Side;
@@ -56,8 +57,8 @@ public class PopupWriter {
 		list.add(sg);
 	}
 
-	@SubscribeEvent
-	public void drawOverlay(RenderGameOverlayEvent evt) {
+	@SubscribeEvent(priority = EventPriority.HIGHEST)
+	public void drawOverlay(RenderGameOverlayEvent.Post evt) {
 		if (!list.isEmpty() && evt.type == ElementType.HELMET) {
 			String s = list.get(0);
 			int x = 2;


### PR DESCRIPTION
Debug overlays should be in the front, because debugging is what someone enables on purpose, so it is important to be in the front.

Popups, like version checker updates, should be in the front, because they usually contain important information that they need to see, and they are dismissable anyway.