### PR TITLE
Suppressing "NoSuchElementException" that is throwed while doing DeepInteract with MESystem

### DIFF
--- a/ModInteract/DeepInteract/MESystemReader.java
+++ b/ModInteract/DeepInteract/MESystemReader.java
@@ -108,7 +108,7 @@ public class MESystemReader implements IMEMonitorHandlerReceiver<IAEItemStack> {
 		actionSource = src;
 
 		IReadOnlyCollection<IGridNode> nodes = ign.getGrid().getNodes();
-		isEmpty = nodes.isEmpty() || (nodes.size() == 1 && nodes.iterator().next() == node);
+		isEmpty = nodes.isEmpty() || (nodes.size() == 1 && nodes.iterator().hasNext() && nodes.iterator().next() == node);
 	}
 
 	public MESystemReader setRequester(ICraftingRequester icr) {


### PR DESCRIPTION
This is to avoid following errors that are spammed on server:
[09:58:39] [Server thread/ERROR] [FML]: DRAGONAPI ERROR: Detected invalid ME system when running Reika.ChromatiCraft.Magic.Artefact.UABombingEffects$1@6e613b24: appeng.me.GridNodeCollection@65562a8c
; Threw exception on access:
[09:58:39] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]: java.util.NoSuchElementException
[09:58:39] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at java.util.HashMap$HashIterator.nextNode(HashMap.java:1444)
[09:58:39] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at java.util.HashMap$KeyIterator.next(HashMap.java:1466)
[09:58:39] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at appeng.me.GridNodeIterator.next(GridNodeIterator.java:78)
[09:58:39] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at appeng.me.GridNodeIterator.next(GridNodeIterator.java:35)
[09:58:39] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at Reika.DragonAPI.ModInteract.DeepInteract.MESystemReader.<init>(MESystemReader.java:111)
[09:58:39] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at Reika.DragonAPI.ModInteract.DeepInteract.MESystemReader.<init>(MESystemReader.java:66)
[09:58:39] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at Reika.DragonAPI.ModInteract.DeepInteract.MESystemReader$ItemInSystemEffect.performEffect(MESystemReader.java:775)
[09:58:39] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at Reika.DragonAPI.ModInteract.DeepInteract.MESystemReader$EffectHandler.tick(MESystemReader.java:424)
[09:58:39] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at Reika.DragonAPI.Auxiliary.Trackers.TickRegistry.serverTick(TickRegistry.java:87)
[09:58:39] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at cpw.mods.fml.common.eventhandler.ASMEventHandler_388_TickRegistry_serverTick_ServerTickEvent.invoke(.dynamic)
[09:58:39] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at cpw.mods.fml.common.eventhandler.ASMEventHandler.invoke(ASMEventHandler.java:54)
[09:58:39] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at cpw.mods.fml.common.eventhandler.EventBus.post(EventBus.java:140)
[09:58:39] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at cpw.mods.fml.common.FMLCommonHandler.onPostServerTick(FMLCommonHandler.java:247)
[09:58:39] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at net.minecraft.server.MinecraftServer.func_71217_p(MinecraftServer.java:590)
[09:58:39] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at fastcraft.at.a(F:978)
[09:58:39] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at fastcraft.H.aq(F:36)
[09:58:39] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at net.minecraft.server.MinecraftServer.run(MinecraftServer.java:396)
[09:58:39] [Server thread/INFO] [STDERR]: [java.lang.Throwable$WrappedPrintStream:println:748]:         at net.minecraft.server.MinecraftServer$2.run(MinecraftServer.java:685)

I know it may actually not be fixing a problem itself but couldn't debug it further without having to recompile everything on my side.