### PR TITLE
Fix NullReferenceError in AbstractSearch's FoundPath

### DIFF
--- a/Instantiable/Data/BlockStruct/AbstractSearch.java
+++ b/Instantiable/Data/BlockStruct/AbstractSearch.java
@@ -204,6 +204,10 @@ public abstract class AbstractSearch {
 		private final LinkedList<Coordinate> path;
 
 		private FoundPath(LinkedList<Coordinate> li) {
+			if (li == null) {
+				path = new LinkedList<Coordinate>();
+				return;
+			}
 			path = li;
 		}
 


### PR DESCRIPTION
Fixed when an empty FoundPath was created by passing null to the constructor, getting the path would cause a NullReferenceError. This only actually caused an issue when called by some items like the bezier crystals

This was bugging me in my recent world so i decided to have a go at fixing it myself. First time doing anything like this if I've done something wrong let me know!